### PR TITLE
fix: professional headline property is now exposed in the response

### DIFF
--- a/src/dtos/res/professional-res.dto.ts
+++ b/src/dtos/res/professional-res.dto.ts
@@ -28,6 +28,10 @@ export class ProfessionalResDto extends BaseResDto {
   @Expose()
   resumeUrl: string;
 
+  @ApiProperty({ type: String })
+  @Expose()
+  headline: string;
+
   @ApiProperty({ type: ProfessionalProjectsResDto })
   @Type(() => ProfessionalProjectsResDto)
   @Expose()


### PR DESCRIPTION
### Your checklist for this pull request

🚨 Things to verify before creating pull request

- [x] Every commit follow the semver format [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Pull request title must also have the semver format since using squash will be the only commit that will appear in the changelog.

### Description

Expose `headline` property.

## Changes

- [x] `headline` property of Professional is now part of its response DTO.

❤️ Thank you!
